### PR TITLE
[#44] Fix EF Migration Bug

### DIFF
--- a/GianLuca.Domain.Core/Entity/BaseEntity.cs
+++ b/GianLuca.Domain.Core/Entity/BaseEntity.cs
@@ -4,14 +4,16 @@ namespace GianLuca.Domain.Core.Entity
 {
     public class BaseEntity
     {
-        public BaseEntity() => Id = Guid.NewGuid();
+        public BaseEntity() => this.Id = Guid.NewGuid();
 
         public BaseEntity(Guid idGuid)
         {
             if (idGuid != Guid.Empty)
-                Id = idGuid;
+            {
+                this.Id = idGuid;
+            }
         }
 
-        public Guid Id { get; }
+        public Guid Id { get; private set; }
     }
 }


### PR DESCRIPTION
This commit fixes bug when using migrations with Entity Framework.
Bug caused by the Id property being readonly.
Corrected setting a private set on property Id.